### PR TITLE
Readme improvements, missing types and laravext version updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,24 +90,28 @@ cp .env.example .env
 composer install
 pnpm install
 ```
-4. Migrate the database migrations
+4. Generate the application key
+```bash
+php artisan key:generate
+```
+5. Migrate the database migrations
 ```bash
 php artisan migrate
 ```
-5. Seed the database
+6. Seed the database
 ```bash
 php artisan db:seed
 ```
-6. Refresh IDE metadata files and generate typescript types
+7. Refresh IDE metadata files and generate typescript types
 ```bash
 composer ide-helper
 composer generate-types
 ```
-7. Start the development server
+8. Start the development server
 ```bash
 npm run dev
 ```
-8. Visit the application at [http://laranext.test](http://laranext.test)
+9. Visit the application at [http://laranext.test](http://laranext.test)
 
 ### Running tests
 The starter-kit uses **Pest** for testing.

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "arthurydalgo/laravext",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ArthurYdalgo/laravext-packagist.git",
-                "reference": "f9c16460f3b28df880c94a13f3a8f1f03309bdeb"
+                "reference": "f000637de36ef3b451eee431a0621c73e65c7076"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ArthurYdalgo/laravext-packagist/zipball/f9c16460f3b28df880c94a13f3a8f1f03309bdeb",
-                "reference": "f9c16460f3b28df880c94a13f3a8f1f03309bdeb",
+                "url": "https://api.github.com/repos/ArthurYdalgo/laravext-packagist/zipball/f000637de36ef3b451eee431a0621c73e65c7076",
+                "reference": "f000637de36ef3b451eee431a0621c73e65c7076",
                 "shasum": ""
             },
             "require": {
@@ -57,7 +57,7 @@
                     "role": "Developer"
                 }
             ],
-            "description": "The Laravel Toolset",
+            "description": "The Laravext Toolset for Laravel",
             "homepage": "https://github.com/arthurydalgo/laravext",
             "keywords": [
                 "arthurydalgo",
@@ -65,9 +65,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ArthurYdalgo/laravext-packagist/issues",
-                "source": "https://github.com/ArthurYdalgo/laravext-packagist/tree/1.0.0"
+                "source": "https://github.com/ArthurYdalgo/laravext-packagist/tree/1.0.1"
             },
-            "time": "2024-08-19T02:38:49+00:00"
+            "time": "2024-08-24T04:12:28+00:00"
         },
         {
             "name": "brick/math",

--- a/resources/js/types/laravext.d.ts
+++ b/resources/js/types/laravext.d.ts
@@ -1,11 +1,12 @@
 declare module "@laravext/react" {
   export const createLaravextApp: any;
   export const createLaravextSsrApp: any;
+  export const Head: any;
+  export const Link: any;
   export const laravextPageData: any;
   export const version: any;
   export const nexus: any;
   export const nexusProps: any;
-  // export function sharedProps<T extends SharedProps>(): Page<T>; // the T generic will combine any type you add to it & the PageProps interface defined in @inertiajs/core
   export const sharedProps: any;
   export const routeParams: any;
   export const routeName: any;


### PR DESCRIPTION
## Readme improvements

The command to generate the APP_KEY was missing. I know that anyone would immediatly see the error when running the project and do it right away, but I just thought it would be a good courtesy to just add it here

## Missing types

There were some missing types in the `/resources/js/types/laravext.d.ts`

## Laravext version updated

I've changed the Laravext version to 1.0.1, to address the [issue #1](https://github.com/ArthurYdalgo/laravext-packagist/issues/1) where the layout file convention was not being sent to the client